### PR TITLE
Update graphs.jl

### DIFF
--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -179,7 +179,7 @@ if Plots.is_installed("LightGraphs")
             dists
         end
 
-        function get_source_destiny_weight(g::LightGraphs.SimpleGraph)
+        function get_source_destiny_weight(g::LightGraphs.AbstractGraph)
             source = Vector{Int}()
             destiny =  Vector{Int}()
             sizehint!(source, LightGraphs.nv(g))
@@ -191,11 +191,11 @@ if Plots.is_installed("LightGraphs")
             get_source_destiny_weight(source, destiny)
         end
 
-        function get_adjacency_matrix(g::LightGraphs.SimpleGraph)
+        function get_adjacency_matrix(g::LightGraphs.Graph)
             get_adjacency_matrix(get_source_destiny_weight(g)...)
         end
 
-        function get_adjacency_list(g::LightGraphs.SimpleGraph)
+        function get_adjacency_list(g::LightGraphs.AbstractGraph)
             g.fadjlist
         end
     end


### PR DESCRIPTION
replace `SimpleGraph` with `AbstractGraph`. Note: this only works with LightGraphs v0.8 and higher, which means it's restricted to Julia v0.6 right now. Backport to LightGraphs v0.7.5 pending.