### PR TITLE
arc and chord diagram as graphplots

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,26 +49,23 @@ graphplot(A,
 
 ![](https://cloud.githubusercontent.com/assets/933338/16094180/0dd2edf0-330d-11e6-8596-d12b0b8d5393.png)
 
+#### Arc and chord diagrams
+
+```julia
+using PlotRecipes
+
+adjmat = Symmetric(sparse(rand(0:1,8,8)));
+
+plot(
+    graphplot(adjmat, method=:chorddiagram),
+    graphplot(adjmat, method=:arcdiagram, markersize=3)
+    )
+```
+![](https://drive.google.com/file/d/0B3LhAPLJWKt9ZHZuRHkwMzZ4Nmc/view?usp=sharing)
 
 #### Fun with algos. Visualizing a stress-driven layout algorithm
 
 ![](https://cloud.githubusercontent.com/assets/933338/16698919/ee1f9e76-451e-11e6-8936-881551f120dd.gif)
-
-#### Arc Diagrams
-
-```julia
-using PlotRecipes
-plot(
-	arcdiagram(['A','A','A','B'], ['B','C','D','A'], [1,2,3,1]),
-	arcdiagram(rand(10), rand(10)),
-	arcdiagram(rand(10), rand(10), rand(10)),
-	arcdiagram(rand(10,10)),
-	arcdiagram(Symmetric(rand(10,10))),
-	arcdiagram(sparse([0 0 0; 1 1 0; 1 1 1]))
-)
-```
-
-![](https://cloud.githubusercontent.com/assets/2822757/16072526/aba39c2e-32b7-11e6-947c-6faab1d13cc7.png)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ plot(
     graphplot(adjmat, method=:chorddiagram),
     graphplot(adjmat, method=:arcdiagram, markersize=3)
     )
-```
-![](https://drive.google.com/file/d/0B3LhAPLJWKt9ZHZuRHkwMzZ4Nmc/view?usp=sharing)
+```  
+![arc and chord diagrams](https://user-images.githubusercontent.com/2822757/27743452-5511e5e2-5dbc-11e7-895e-dfa753a84efc.png)  
 
 #### Fun with algos. Visualizing a stress-driven layout algorithm
 

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -12,4 +12,7 @@ include("graphs.jl")
 include("finance.jl")
 include("misc.jl")
 
+@deprecate arcdiagram graphplot
+@deprecate chorddiagram graphplot
+
 end # module

--- a/src/graph_layouts.jl
+++ b/src/graph_layouts.jl
@@ -320,3 +320,34 @@ end
 # -----------------------------------------------------
 
 # TODO: maybe also implement Catmull-Rom Splines? http://www.mvps.org/directx/articles/catmull/
+
+# -----------------------------------------------------
+
+function arc_diagram(source::AbstractVector{Int},
+                     destiny::AbstractVector{Int},
+                     weights::AbstractVector;
+                     kw...)
+    X = unique(vcat(source, destiny))
+    O = zeros(Int,length(X))
+    X, O, O
+end
+
+# -----------------------------------------------------
+
+function chord_diagram( source::AbstractVector{Int},
+                        destiny::AbstractVector{Int},
+                        weights::AbstractVector;
+                        kw... )
+    nodes = unique(vcat(source, destiny))
+    N = length(nodes)
+    δ = 2pi / N
+
+    x = Array(Float64,N)
+    y = Array(Float64,N)
+    for i in 1:N
+        x[i] = sin((i-1)*δ)
+        y[i] = cos((i-1)*δ)
+    end
+    
+    x, y, zeros(Int,length(x))
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,3 +80,28 @@ function random_control_point(xi, xj, yi, yj, curvature_scalar)
     (xmid + dist_from_mid * cos(theta),
      ymid + dist_from_mid * sin(theta))
 end
+
+# for chord diagrams:
+function arcshape(θ1, θ2)
+    Shape(vcat(
+        Plots.partialcircle(θ1, θ2, 15, 1.05),
+        reverse(Plots.partialcircle(θ1, θ2, 15, 0.95))
+    ))
+end
+
+# x and y limits for arc diagram ()
+function arcdiagram_limits(x, source, destiny)
+    @assert length(x) >= 2
+    margin = abs(0.1*(x[2] - x[1]))
+    xmin, xmax = extrema(x)
+    r = abs(0.5 * (xmax - xmin))
+    mean_upside = mean(source .< destiny)
+    ylims = if mean_upside == 1.0
+        (-margin, r+margin)
+    elseif mean_upside == 0.0
+        (-r-margin, margin)
+    else
+        (-r-margin, r+margin)
+    end
+    (xmin-margin, xmax+margin), ylims
+end


### PR DESCRIPTION
Arc and chord diagrams are broken for Julia 0.5. This solves it, making arc and chord diagrams part of `graphplot`. `arcdiagram` and `chorddiagram` are not longer exported, they should be used as methods to `graphplot`:

```julia
using PlotRecipes

adjmat = Symmetric(sparse(rand(0:1,8,8)));

plot(
    graphplot(adjmat, method=:chorddiagram),
    graphplot(adjmat, method=:arcdiagram, markersize=3)
    )
```
![chord_arc_diagram](https://user-images.githubusercontent.com/2822757/27743452-5511e5e2-5dbc-11e7-895e-dfa753a84efc.png)

